### PR TITLE
Fix react-router dev shenanigans

### DIFF
--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -3,5 +3,5 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "src",
   ssr: false,
-  basename: process.env.VITE_BASENAME,
+  basename: process?.env?.VITE_BASENAME ?? '/',
 } satisfies Config;


### PR DESCRIPTION
For some strange reason react-router dev does not load .env files on startup, only after first hot reload.